### PR TITLE
BoostTestTargets.cmake: support CMake 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,12 @@ endif()
 
 find_package(Boost REQUIRED)
 set (BOOST_CXX_FLAGS "-DBOOST_BIMAP_DISABLE_SERIALIZATION")
+
+if (NOT Boost_VERSION_MACRO)
+	# Compatibility with pre CMP0093 (CMake 3.15)
+	set(Boost_VERSION_MACRO ${Boost_VERSION})
+endif()
+
 include(BoostTestTargets)
 
 if(SIMGEAR_HEADLESS)

--- a/CMakeModules/BoostTestTargets.cmake
+++ b/CMakeModules/BoostTestTargets.cmake
@@ -46,11 +46,11 @@ set(BOOST_TEST_TARGET_PREFIX "test")
 if(NOT Boost_FOUND)
 	find_package(Boost 1.34.0 QUIET)
 endif()
-if("${Boost_VERSION}0" LESS "1034000")
+if("${Boost_VERSION_MACRO}0" LESS "1034000")
 	set(_shared_msg
 		"NOTE: boost::test-based targets and tests cannot "
 		"be added: boost >= 1.34.0 required but not found. "
-		"(found: '${Boost_VERSION}'; want >=103400) ")
+		"(found: '${Boost_VERSION_MACRO}'; want >=103400) ")
 	if(ENABLE_TESTS)
 		message(FATAL_ERROR
 			${_shared_msg}
@@ -66,7 +66,7 @@ endif()
 include(GetForceIncludeDefinitions)
 include(CopyResourcesToBuildTree)
 
-if(Boost_FOUND AND NOT "${Boost_VERSION}0" LESS "1034000")
+if(Boost_FOUND AND NOT "${Boost_VERSION_MACRO}0" LESS "1034000")
 	set(_boosttesttargets_libs)
 	set(_boostConfig "BoostTestTargetsIncluded.h")
 	if(NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY)
@@ -129,7 +129,7 @@ function(add_boost_test _name)
 			"Syntax error in use of add_boost_test: at least one source file required!")
 	endif()
 
-	if(Boost_FOUND AND NOT "${Boost_VERSION}0" LESS "1034000")
+	if(Boost_FOUND AND NOT "${Boost_VERSION_MACRO}0" LESS "1034000")
 
 		include_directories(${Boost_INCLUDE_DIRS})
 
@@ -221,7 +221,7 @@ function(add_boost_test _name)
 			set(_test_command ${_target_name})
 		endif()
 
-		if(TESTS AND ( "${Boost_VERSION}" VERSION_GREATER "103799" ))
+		if(TESTS AND ( "${Boost_VERSION_MACRO}" VERSION_GREATER "103799" ))
 			foreach(_test ${TESTS})
 				add_test(
 					${_name}-${_test}


### PR DESCRIPTION
Without this change `cmake` step fails with

```
=== Starting src_configure                                                                                                                                                                
-- CMAKE Build type: None                                                                                                                                                                 
-- The C compiler identification is GNU 9.2.0                                                                                                                                             
cmake -DCMAKE_COLOR_MAKEFILE:BOOL=TRUE -DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=None -DCMAKE_C_FLAGS:STRING=-pipe -march=native -mtune=native -O2 -fdiagnostics-color=
always -DCMAKE_CXX_FLAGS:STRING=-march=native -O2 -pipe -DCMAKE_AR:PATH=x86_64-pc-linux-gnu-ar -DCMAKE_RANLIB:PATH=x86_64-pc-linux-gnu-ranlib -DCMAKE_NM:PATH=x86_64-pc-linux-gnu-nm -DCMA
KE_C_COMPILER:PATH=x86_64-pc-linux-gnu-cc -DCMAKE_CXX_COMPILER:PATH=x86_64-pc-linux-gnu-c++ -DCMAKE_INSTALL_PREFIX:PATH=/usr/x86_64-pc-linux-gnu -DCMAKE_FIND_ROOT_PATH=/usr/x86_64-pc-lin
ux-gnu -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM:STRING=NEVER -DCMAKE_SYSTEM_PREFIX_PATH:PATH=/usr/x86_64-pc-linux-gnu -DCMAKE_INSTALL_LIBDIR:STRING=lib -DCMAKE_INSTALL_DATAROOTDIR:PATH=/usr/s
hare/ -DSIMGEAR_SHARED:BOOL=ON -DSYSTEM_EXPAT:BOOL=ON -DSYSTEM_UDNS:BOOL=ON -DENABLE_gdal:BOOL=TRUE -DENABLE_openmp:BOOL=TRUE /var/tmp/paludis/build/de
v-games-simgear-2019.1.1/work/simgear-2019.1.1                                                                                                                                            
-- The CXX compiler identification is GNU 9.2.0                                                                                                                                           
-- Check for working C compiler: /usr/bin/x86_64-pc-linux-gnu-cc                                                                                                                          
-- Check for working C compiler: /usr/bin/x86_64-pc-linux-gnu-cc -- works                                                                                                                 
-- Detecting C compiler ABI info                                                                                                                                                          
-- Detecting C compiler ABI info - done                                                                                                                                                   
-- Detecting C compile features                                                                                                                                                           
-- Detecting C compile features - done                                                                                                                                                    
-- Check for working CXX compiler: /usr/bin/x86_64-pc-linux-gnu-c++                                                                                                                       
-- Check for working CXX compiler: /usr/bin/x86_64-pc-linux-gnu-c++ -- works                                                                                                              
-- Detecting CXX compiler ABI info                                                                                                                                                        
-- Detecting CXX compiler ABI info - done                                                                                                                                                 
-- Detecting CXX compile features                                                                                                                                                         
-- Detecting CXX compile features - done                                                                                                                                                  
-- version is 2019 dot 1 dot 1                                                                                                                                                            
-- Library installation directory: lib                                                                                                                                                    
-- Looking for pthread.h                                                                                                                                                                  
-- Looking for pthread.h - found                                                                                                                                                          
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD                                                                                                                                                
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed                                                                                                                                       
-- Looking for pthread_create in pthreads                                                                                                                                                 
-- Looking for pthread_create in pthreads - not found                                                                                                                                     
-- Looking for pthread_create in pthread                                                                                                                                                  
-- Looking for pthread_create in pthread - found                                                                                                                                          
-- Found Threads: TRUE                                                                                                                                                                    
-- Found Boost: /usr/x86_64-pc-linux-gnu/lib64/cmake/Boost-1.71.0/BoostConfig.cmake (found version "1.71.0")                                                                              
-- Configuring incomplete, errors occurred!                                                                                                                                               
See also "/var/tmp/paludis/build/dev-games-simgear-2019.1.1/work/build/CMakeFiles/CMakeOutput.log".                                                                                       
See also "/var/tmp/paludis/build/dev-games-simgear-2019.1.1/work/build/CMakeFiles/CMakeError.log".                                                                                        
CMake Error at CMakeModules/BoostTestTargets.cmake:55 (message):                                                                                                                          
  NOTE: boost::test-based targets and tests cannot be added: boost >= 1.34.0                                                                                                              
  required but not found.  (found: '1.71.0' want >=103400) You may disable                                                                                                                
  ENABLE_TESTS to continue without the tests.                                                                                                                                             
Call Stack (most recent call first):                                                                                                                                                      
  CMakeLists.txt:220 (include)                                                                                                                                                            
```

This caused by [`CMP0093` policy](https://cmake.org/cmake/help/v3.15/policy/CMP0093.html). Note that I have `cmake` version 3.15.3. Despite of documentation it looks like default behavior is `NEW`. I tried to override it with `-DCMAKE_POLICY_DEFAULT_CMP0093=OLD`, but it didn't worked. Thus I guess better to switch to new behavior.